### PR TITLE
mingw compile fix

### DIFF
--- a/profiler.h
+++ b/profiler.h
@@ -82,7 +82,12 @@ void _profiler_node_setup(int id, const char* name);
 
 #ifdef _WIN32
 #include <Windows.h>
+
+#ifdef __MINGW32__
+#include <x86intrin.h>
+#else
 #include <intrin.h>
+#endif
 static uint64_t get_cycles()
 {
 	return __rdtsc();


### PR DESCRIPTION
mingw does not supply `intrin.h` required for the Windows part of the code. This adds a check for the mingw compiler and includes `x86intrin.h` instead.

Tested on mingw32 and VS2015.